### PR TITLE
Keith fiddling around

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version=2.7.5
 align = more
-maxColumn = 120
+maxColumn = 80
 continuationIndent.defnSite = 2
 danglingParentheses = true
 rewrite.rules = [SortImports, RedundantBraces, RedundantParens, SortModifiers]

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,8 @@ Test / testOptions +=
 libraryDependencies ++= Seq(
   "org.typelevel"     %% "cats-core"       % catsVersion,
   "org.scalactic"     %% "scalactic"       % "3.2.13",
-  "org.scalatest"     %% "scalatest"       % "3.2.13"  % "test",
+  "org.scalatest"     %% "scalatest"       % "3.2.13"  % Test,
   "org.scalatestplus" %% "scalacheck-1-14" % "3.1.2.0" % Test,
-  "org.scalacheck"    %% "scalacheck"      % "1.14.1"  % "test",
+  "org.scalacheck"    %% "scalacheck"      % "1.14.1"  % Test,
   "org.typelevel"     %% "cats-effect"     % "3.3.12"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.7.2

--- a/src/main/scala/poker/Deck.scala
+++ b/src/main/scala/poker/Deck.scala
@@ -1,8 +1,8 @@
 package poker
 
-import cats.effect.IO
-
-import scala.util.Random
+import cats._
+import cats.effect.std._
+import cats.syntax.all._
 
 case class Deck(cards: List[Card]) {
 //  def size: Int = cards.length
@@ -21,12 +21,17 @@ case class Deck(cards: List[Card]) {
 
 object Deck {
 
-  trait StartingDeck {}
+  trait StartingDeck {
+    def shuffle[F[_]: Functor: Random]: F[StartingDeck]
+  }
 
-  final private case class StartingDeckImpl(cards: List[Card]) extends StartingDeck {}
+  final private case class StartingDeckImpl(cards: List[Card]) extends StartingDeck {
+    override def shuffle[F[_]: Functor: Random]: F[StartingDeck] =
+      Random[F].shuffleList(cards).map(StartingDeckImpl.apply)
+  }
 
-  object StartingDeck {
-//    def shuffle: IO[StartingDeck] = IO(StartingDeckImpl(Random.shuffle(startingDeckImpl.cards)))
+  object StartingDeck { // TODO flatten nesting?
+//    def shuffle: IO[StartingDeck] =
 
     private def startingDeckImpl: StartingDeckImpl = {
       val cardList = for {

--- a/src/main/scala/poker/Hand.scala
+++ b/src/main/scala/poker/Hand.scala
@@ -23,8 +23,6 @@ object Hand {
       case HighCard(x)      => x
     }
 
-  final case class UnrankedHand() extends Hand
-
   final case class StraightFlush(rank: Rank) extends Hand {
     override val score = 9
   }

--- a/src/main/scala/poker/Hand.scala
+++ b/src/main/scala/poker/Hand.scala
@@ -35,7 +35,7 @@ object Hand {
     override val score = 7
   }
 
-  final case class Flush(rank: Rank) extends Hand {
+  final case class Flush(rank: Rank, kickers: List[Card]) extends Hand {
     override val score = 6
   }
 
@@ -121,7 +121,7 @@ object Hand {
         }
 
       groupBySuit5Count.collectFirst { case (_, cards) =>
-        Flush(cards.max.rank)
+        Flush(cards.max.rank, cards.sorted.reverse)
       }
     }
   }
@@ -164,6 +164,7 @@ object Hand {
         .filter(_._2.size == 2)
         .toList
         .sortBy(_._1.value)
+        .reverse
 
       for {
         head <- pairsGrouped.headOption

--- a/src/main/scala/poker/OrderInstances.scala
+++ b/src/main/scala/poker/OrderInstances.scala
@@ -17,7 +17,9 @@ object OrderInstances {
           case (a: FullHouse, b: FullHouse) =>
             if (a.rank1.value - b.rank1.value != 0) a.rank1.value - b.rank1.value
             else a.rank2.value - b.rank2.value
-          case (a: Flush, b: Flush)       => a.rank.value - b.rank.value
+          case (a: Flush, b: Flush) => // a.rank.value - b.rank.value
+            if (a.rank.value - b.rank.value != 0) a.rank.value - b.rank.value
+            else compareCorresponding(a.kickers, b.kickers)
           case (a: Straight, b: Straight) => a.rank.value - b.rank.value
           case (a: ThreeOfAKind, b: ThreeOfAKind) =>
             if (a.rank.value - b.rank.value != 0) a.rank.value - b.rank.value

--- a/src/main/scala/poker/ShowDown.scala
+++ b/src/main/scala/poker/ShowDown.scala
@@ -26,20 +26,20 @@ object ShowDown {
 
   def fromPreFlop(preflop: Preflop): Option[NonEmptySet[Int]] = {
 
-    val flop  = Street.deal(preflop)
-    val turn  = Street.deal(flop)
-    val river = Street.deal(turn)
+    val flop  = Street.dealFlop(preflop)
+    val turn  = Street.dealTurn(flop)
+    val river = Street.dealRiver(turn)
     from(river)
   }
 
   def fromFlop(flop: Flop): Option[NonEmptySet[Int]] = {
-    val turn  = Street.deal(flop)
-    val river = Street.deal(turn)
+    val turn  = Street.dealTurn(flop)
+    val river = Street.dealRiver(turn)
     from(river)
   }
 
   def fromTurn(turn: Turn): Option[NonEmptySet[Int]] = {
-    val river = Street.deal(turn)
+    val river = Street.dealRiver(turn)
     from(river)
   }
 

--- a/src/main/scala/poker/ShowDown.scala
+++ b/src/main/scala/poker/ShowDown.scala
@@ -72,6 +72,7 @@ object PlayerStanding {
       .zipWithIndex
       .map { case ((p, h), i) => (i, p, h) }
 
+//TODO this must be wrong??
   def winnerList(board: Street): Option[NonEmptySet[(Int, Player, Hand)]] = {
     val winners = PlayerStanding(board).maximumByList { case (_, _, hand) => hand }.toSet
 

--- a/src/main/scala/poker/Street.scala
+++ b/src/main/scala/poker/Street.scala
@@ -29,25 +29,12 @@ object Street {
       players = cards
         .take(numHoleCards)
         .grouped(2)
-        .map { case List(x, y) => Player(x, y) }
+        .map { case List(x, y) => Player(x, y) } // TODO unsafe
         .toList
     } yield Preflop(players, PreFlopDeckImpl(cards.drop(numHoleCards))) // TODO I've broken encapuslation here
 
 //    deck.map(Preflop(players, _))
   }
-
-  //TODo: come back and fix the unapply
-  def deal(boardState: Street): Street =
-    boardState match {
-      //      case Preflop(ps, d)                        => dealFlop(ps, d)
-      //      case BoardState.Flop(ps, d, c1, c2, c3)    => dealTurn(ps, d, c1, c2, c3)
-      //      case BoardState.Turn(ps, d, c1, c2, c3, t) => dealRiver(ps, d, c1, c2, c3, t)
-      //      case BoardState.River(ps, d, c1, c2, c3, t, r) => ???
-      case x: Preflop => dealFlop(x.players, x.deck) // flop factory
-      case x: Flop    => dealTurn(x.players, x.deck, x.card1, x.card2, x.card3)
-      case x: Turn    => dealRiver(x.players, x.deck, x.card1, x.card2, x.card3, x.turn)
-      case x: River   => x
-    }
 
   final case class Preflop(players: List[Player], deck: PreflopDeck) extends Street {
 
@@ -83,23 +70,21 @@ object Street {
   /// State machine needs to go to the Deck. (FlopCards, FlopDeck)
   // Flop - street
   // FlopCards - the three cards
-  def dealFlop(players: List[Player], deck: PreflopDeck): Flop = { // (FlopCards, FlopDeck)
+  def dealFlop(preflop: Preflop): Flop = { // (FlopCards, FlopDeck)
 
-    val (flop, flopDeck) = deck.dealFlop
-    Flop(players, flopDeck, flop.card1, flop.card2, flop.card3)
+    val (flop, flopDeck) = preflop.deck.dealFlop
+    Flop(preflop.players, flopDeck, flop.card1, flop.card2, flop.card3)
   }
 
-  def dealTurn(players: List[Player], deck: FlopDeck, fl1: Card, fl2: Card, fl3: Card): Turn = {
+  def dealTurn(flop: Flop): Turn = {
+    val (turn, turnDeck) = flop.deck.dealTurn
 
-    val (turn, turnDeck) = deck.dealTurn
-
-    Turn(players, turnDeck, fl1, fl2, fl3, turn.card)
+    Turn(flop.players, turnDeck, flop.card1, flop.card2, flop.card3, turn.card)
   }
 
-  def dealRiver(players: List[Player], deck: TurnDeck, fl1: Card, fl2: Card, fl3: Card, t: Card): River = {
-
-    val river = deck.dealRiver
-    River(players, fl1, fl2, fl3, t, river.card)
+  def dealRiver(turn: Turn): River = {
+    val river = turn.deck.dealRiver
+    River(turn.players, turn.card1, turn.card2, turn.card3, turn.turn, river.card)
   }
 
 }

--- a/src/test/scala/EquityTest/StreetTest.scala
+++ b/src/test/scala/EquityTest/StreetTest.scala
@@ -11,7 +11,7 @@ import poker.Hand._
 import poker.OrderInstances.{handOrder, handOrdering}
 import pokerData.BoardGenerators._
 
-object StreetTest extends Properties("BoardState Tests") {
+object StreetTest extends Properties("Street Tests") {
 
   // genFlop, genTurn, genRiver
   // genPlayer,
@@ -44,29 +44,6 @@ object StreetTest extends Properties("BoardState Tests") {
     allDealtCards.distinct ?= allDealtCards
 
   }
-  property("Preflop: If the winner is a pair, no more than two players can be winning ") = forAll(genPreflopBoard) {
-    preFlop =>
-      val winnerList = PlayerStanding.winnerList(preFlop)
-
-      val winningRank = winnerList.get.map(_._3).fold(HighCard(Two, List.empty[Card])) { case (s: Hand, v: Hand) =>
-        if (handOrder.compare(s, v) > 0) s else v
-      }
-      if ((winningRank.score == 2) && (winnerList.get.size > 2)) false
-      else if (winningRank.score > 2) false
-      else true
-  }
-
-  property("Preflop: If the winner is a HighCard, no more than 4 players can be winning ") = forAll(genPreflopBoard) {
-    preFlop =>
-      val winnerList = PlayerStanding.winnerList(preFlop)
-
-      val winningRank = winnerList.get.map(_._3).fold(HighCard(Two, List.empty[Card])) { case (s: Hand, v: Hand) =>
-        if (handOrder.compare(s, v) > 0) s else v
-      }
-      if ((winningRank.score == 1) && (winnerList.get.size > 4)) false
-      else if (winningRank.score > 2) false
-      else true
-  }
 
   //  property("preflop deck size equals 52 minus the players cards and maintains uniqueness") = forAll(genPreflopBoard, genNumberOfPlayers) {
 //    (preFlopBoard, numPlayers) =>
@@ -79,15 +56,5 @@ object StreetTest extends Properties("BoardState Tests") {
 //      playerCards.distinct.size == playerCards.size &&
 //      preFlopBoard.deck.cards.distinct.size == preFlopBoard.deck.size
 //  }
-
-// TODO This is not a ShowDown operation, I'm asking what the current hand street is!!!
-  property("Flop: more than one player can NOT have quads") = forAll(genFlopBoard) { flop =>
-    ShowDown(flop.allHands).count(p =>
-      p match {
-        case _: FourOfAKind => true
-        case _              => false
-      }
-    ) <= 1
-  }
 
 }

--- a/src/test/scala/EquityTest/StreetTest.scala
+++ b/src/test/scala/EquityTest/StreetTest.scala
@@ -5,8 +5,8 @@ import cats.implicits.catsSyntaxPartialOrder
 import org.scalacheck.Prop.{forAll, propBoolean, AnyOperators}
 import org.scalacheck.Properties
 import poker.Deck.StartingDeck
-import poker.Street.{deal, Flop, River, Turn}
-import poker.{Card, Hand, PlayerStanding, ShowDown, Street, Two}
+import poker.Street._
+import poker._
 import poker.Hand._
 import poker.OrderInstances.{handOrder, handOrdering}
 import pokerData.BoardGenerators._
@@ -16,8 +16,8 @@ object StreetTest extends Properties("Street Tests") {
   // genFlop, genTurn, genRiver
   // genPlayer,
 
-  property("Preflop hands can never be ranked higher than a Pair") = forAll(genPreflopBoard) { preFlop =>
-    preFlop.players.exists(p =>
+  property("Preflop hands can never be ranked higher than a Pair") = forAll { (preflop: Street.Preflop) =>
+    preflop.players.exists(p =>
       Hand.rank(List(p.card1, p.card2)) match {
         case _: Pair | _: HighCard => true
         case _                     => false
@@ -25,8 +25,8 @@ object StreetTest extends Properties("Street Tests") {
     ) ?= true
   }
 
-  property("The winning hand Preflop is a pair or less") = forAll(genPreflopBoard) { preFlop =>
-    ShowDown(preFlop.allHands).exists(handRank =>
+  property("The winning hand Preflop is a pair or less") = forAll { (preflop: Street.Preflop) =>
+    ShowDown(preflop.allHands).exists(handRank =>
       handRank match {
         case _: Pair | _: HighCard => true
         case _                     => false
@@ -34,10 +34,10 @@ object StreetTest extends Properties("Street Tests") {
     ) ?= true
   }
 
-  property("No card is ever dealt more than once through to the River") = forAll(genPreflopBoard) { preflop =>
-    val flop          = deal(preflop)
-    val turn          = deal(flop)
-    val river         = deal(turn).asInstanceOf[River] // TODo Does this mean that I need to change the Street trait/contract
+  property("No card is ever dealt more than once through to the River") = forAll { (preflop: Street.Preflop) =>
+    val flop          = dealFlop(preflop)
+    val turn          = dealTurn(flop)
+    val river         = dealRiver(turn) // TODo Does this mean that I need to change the Street trait/contract
     val riverCards    = List(river.card1, river.card2, river.card3, river.turn, river.river)
     val holeCards     = preflop.players.collect(p => List(p.card1, p.card2)).flatten
     val allDealtCards = holeCards :: riverCards

--- a/src/test/scala/pokerTest/PlayerStandingTest.scala
+++ b/src/test/scala/pokerTest/PlayerStandingTest.scala
@@ -1,0 +1,49 @@
+package pokerTest
+
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+import poker.Hand.{FourOfAKind, HighCard}
+import poker.OrderInstances.handOrder
+import poker.{Card, Hand, PlayerStanding, Two}
+import pokerData.BoardGenerators.{genFlopBoard, genPreflopBoard}
+
+object PlayerStandingTest extends Properties("Player Standing Tests") {
+
+  property("Preflop: If the winner is a pair, no more than two players can be winning ") = forAll(genPreflopBoard) {
+    preFlop =>
+      val winnerList = PlayerStanding.winnerList(preFlop)
+
+      val winningRank = winnerList.get.map(_._3).fold(HighCard(Two, List.empty[Card])) { case (s: Hand, v: Hand) =>
+        if (handOrder.compare(s, v) > 0) s else v
+      }
+      if ((winningRank.score == 2) && (winnerList.get.size > 2)) false
+      else if (winningRank.score > 2) false
+      else true
+  }
+
+  property("Preflop: If the winner is a HighCard, no more than 4 players can be winning ") = forAll(genPreflopBoard) {
+    preFlop =>
+      val winnerList = PlayerStanding.winnerList(preFlop)
+
+      val winningRank = winnerList.get.map(_._3).fold(HighCard(Two, List.empty[Card])) { case (s: Hand, v: Hand) =>
+        if (handOrder.compare(s, v) > 0) s else v
+      }
+      if ((winningRank.score == 1) && (winnerList.get.size > 4)) false
+      else if (winningRank.score > 2) false
+      else true
+  }
+
+  property("No more than one player can have quads on the Flop") = forAll(genFlopBoard) { flop =>
+    val quadWinners = for {
+      winners <- PlayerStanding.winnerList(flop)
+    } yield winners.count { case (_, _, hand) =>
+      hand match {
+        case _: FourOfAKind => true
+        case _              => false
+      }
+    } <= 1
+
+    quadWinners.get
+  }
+
+}

--- a/src/test/scala/pokerTest/PlayerStandingTest.scala
+++ b/src/test/scala/pokerTest/PlayerStandingTest.scala
@@ -1,17 +1,18 @@
 package pokerTest
 
-import org.scalacheck.Prop.{forAll, AnyOperators}
+import org.scalacheck.Prop._
 import org.scalacheck.Properties
-import poker.Hand.{Flush, FourOfAKind, FullHouse, HighCard, Straight, StraightFlush, ThreeOfAKind, TwoPair}
+import poker.Hand._
 import poker.OrderInstances.handOrder
-import poker.{Card, Hand, PlayerStanding, Two}
-import pokerData.BoardGenerators.{genFlopBoard, genPreflopBoard}
+import poker._
+import pokerData.BoardGenerators._
+import poker.Street
 
 object PlayerStandingTest extends Properties("Player Standing Tests") {
 
-  property("Preflop: If the winner is a pair, no more than two players can be winning ") = forAll(genPreflopBoard) {
-    preFlop =>
-      val winnerList = PlayerStanding.winnerList(preFlop)
+  property("Preflop: If the winner is a pair, no more than two players can be winning ") = forAll {
+    (preflop: Street.Preflop) =>
+      val winnerList = PlayerStanding.winnerList(preflop)
 
       val winningRank = winnerList.get.map(_._3).fold(HighCard(Two, List.empty[Card])) { case (s: Hand, v: Hand) =>
         if (handOrder.compare(s, v) > 0) s else v
@@ -21,9 +22,9 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
       else true
   }
 
-  property("Preflop: If the winner is a HighCard, no more than 4 players can be winning ") = forAll(genPreflopBoard) {
-    preFlop =>
-      val winnerList = PlayerStanding.winnerList(preFlop)
+  property("Preflop: If the winner is a HighCard, no more than 4 players can be winning ") = forAll {
+    (preflop: Street.Preflop) =>
+      val winnerList = PlayerStanding.winnerList(preflop)
 
       val winningRank = winnerList.get.map(_._3).fold(HighCard(Two, List.empty[Card])) { case (s: Hand, v: Hand) =>
         if (handOrder.compare(s, v) > 0) s else v
@@ -33,7 +34,7 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
       else true
   }
 
-  property("No more than one player can have quads on the Flop") = forAll(genFlopBoard) { flop =>
+  property("No more than one player can have quads on the Flop") = forAll { (flop: Street.Flop) =>
     PlayerStanding(flop).count { case (_, _, hand) =>
       hand match {
         case _: FourOfAKind => true
@@ -42,7 +43,7 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
     } <= 1
   }
 
-  property("No more than two players can have a StraightFlush on the Flop") = forAll(genFlopBoard) { flop =>
+  property("No more than two players can have a StraightFlush on the Flop") = forAll { (flop: Street.Flop) =>
     PlayerStanding(flop).count { case (_, _, hand) =>
       hand match {
         case _: StraightFlush => true
@@ -51,7 +52,7 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
     } <= 2
   }
 
-  property("No more than two players can have a winning FullHouse on the Flop") = forAll(genFlopBoard) { flop =>
+  property("No more than two players can have a winning FullHouse on the Flop") = forAll { (flop: Street.Flop) =>
     val strFLWinners = for {
       winners <- PlayerStanding.winnerList(flop)
     } yield winners.count { case (_, _, hand) =>
@@ -63,7 +64,7 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
     strFLWinners.get // TODO why do I always end up with something unsafe??
   }
 
-  property("No more than one player can have a winning Flush on the Flop") = forAll(genFlopBoard) { flop =>
+  property("No more than one player can have a winning Flush on the Flop") = forAll { (flop: Street.Flop) =>
     val flushWinners = for {
       winners <- PlayerStanding.winnerList(flop)
     } yield winners.count { case (_, _, hand) =>
@@ -75,7 +76,7 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
     flushWinners.get ?= true // TODO why do I always end up with something unsafe??
   }
 
-  property("No more than 5 players can have a Flush on the Flop") = forAll(genFlopBoard) { flop =>
+  property("No more than 5 players can have a Flush on the Flop") = forAll { (flop: Street.Flop) =>
     PlayerStanding(flop).count { case (_, _, hand) =>
       hand match {
         case _: Flush => true
@@ -84,7 +85,7 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
     } <= 5
   }
 
-  property("No more than 4 players can have a winning Straight on the Flop") = forAll(genFlopBoard) { flop =>
+  property("No more than 4 players can have a winning Straight on the Flop") = forAll { (flop: Street.Flop) =>
     val straightWinners = for {
       winners <- PlayerStanding.winnerList(flop)
     } yield winners.count { case (_, _, hand) =>
@@ -96,7 +97,7 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
     straightWinners.get ?= true // TODO why do I always end up with something unsafe??
   }
 
-  property("No more than 4 players can have a winning ThreeOfAKind on the Flop") = forAll(genFlopBoard) { flop =>
+  property("No more than 4 players can have a winning ThreeOfAKind on the Flop") = forAll { (flop: Street.Flop) =>
     val setWinners = for {
       winners <- PlayerStanding.winnerList(flop)
     } yield winners.count { case (_, _, hand) =>
@@ -108,7 +109,7 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
     setWinners.get ?= true
   }
 
-  property("No more than 3 players can have a winning TwoPair on the Flop") = forAll(genFlopBoard) { flop =>
+  property("No more than 3 players can have a winning TwoPair on the Flop") = forAll { (flop: Street.Flop) =>
     val twoPairWinners = for {
       winners <- PlayerStanding.winnerList(flop)
     } yield winners.count { case (_, _, hand) =>

--- a/src/test/scala/pokerTest/PlayerStandingTest.scala
+++ b/src/test/scala/pokerTest/PlayerStandingTest.scala
@@ -1,8 +1,8 @@
 package pokerTest
 
-import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop.{forAll, AnyOperators}
 import org.scalacheck.Properties
-import poker.Hand.{FourOfAKind, HighCard}
+import poker.Hand.{Flush, FourOfAKind, FullHouse, HighCard, Straight, StraightFlush, ThreeOfAKind, TwoPair}
 import poker.OrderInstances.handOrder
 import poker.{Card, Hand, PlayerStanding, Two}
 import pokerData.BoardGenerators.{genFlopBoard, genPreflopBoard}
@@ -34,16 +34,91 @@ object PlayerStandingTest extends Properties("Player Standing Tests") {
   }
 
   property("No more than one player can have quads on the Flop") = forAll(genFlopBoard) { flop =>
-    val quadWinners = for {
-      winners <- PlayerStanding.winnerList(flop)
-    } yield winners.count { case (_, _, hand) =>
+    PlayerStanding(flop).count { case (_, _, hand) =>
       hand match {
         case _: FourOfAKind => true
         case _              => false
       }
     } <= 1
-
-    quadWinners.get
   }
 
+  property("No more than two players can have a StraightFlush on the Flop") = forAll(genFlopBoard) { flop =>
+    PlayerStanding(flop).count { case (_, _, hand) =>
+      hand match {
+        case _: StraightFlush => true
+        case _                => false
+      }
+    } <= 2
+  }
+
+  property("No more than two players can have a winning FullHouse on the Flop") = forAll(genFlopBoard) { flop =>
+    val strFLWinners = for {
+      winners <- PlayerStanding.winnerList(flop)
+    } yield winners.count { case (_, _, hand) =>
+      hand match {
+        case _: FullHouse => true
+        case _            => false
+      }
+    } <= 2
+    strFLWinners.get // TODO why do I always end up with something unsafe??
+  }
+
+  property("No more than one player can have a winning Flush on the Flop") = forAll(genFlopBoard) { flop =>
+    val flushWinners = for {
+      winners <- PlayerStanding.winnerList(flop)
+    } yield winners.count { case (_, _, hand) =>
+      hand match {
+        case _: Flush => true
+        case _        => false
+      }
+    } <= 1
+    flushWinners.get ?= true // TODO why do I always end up with something unsafe??
+  }
+
+  property("No more than 5 players can have a Flush on the Flop") = forAll(genFlopBoard) { flop =>
+    PlayerStanding(flop).count { case (_, _, hand) =>
+      hand match {
+        case _: Flush => true
+        case _        => false
+      }
+    } <= 5
+  }
+
+  property("No more than 4 players can have a winning Straight on the Flop") = forAll(genFlopBoard) { flop =>
+    val straightWinners = for {
+      winners <- PlayerStanding.winnerList(flop)
+    } yield winners.count { case (_, _, hand) =>
+      hand match {
+        case _: Straight => true
+        case _           => false
+      }
+    } <= 4
+    straightWinners.get ?= true // TODO why do I always end up with something unsafe??
+  }
+
+  property("No more than 4 players can have a winning ThreeOfAKind on the Flop") = forAll(genFlopBoard) { flop =>
+    val setWinners = for {
+      winners <- PlayerStanding.winnerList(flop)
+    } yield winners.count { case (_, _, hand) =>
+      hand match {
+        case _: ThreeOfAKind => true
+        case _               => false
+      }
+    } <= 4
+    setWinners.get ?= true
+  }
+
+  property("No more than 3 players can have a winning TwoPair on the Flop") = forAll(genFlopBoard) { flop =>
+    val twoPairWinners = for {
+      winners <- PlayerStanding.winnerList(flop)
+    } yield winners.count { case (_, _, hand) =>
+      hand match {
+        case _: TwoPair => true
+        case _          => false
+      }
+    } <= 3
+    println(PlayerStanding.winnerList(flop))
+    twoPairWinners.get ?= true
+
+  }
 }

--- a/src/test/scala/pokerTest/RankingTest.scala
+++ b/src/test/scala/pokerTest/RankingTest.scala
@@ -163,6 +163,17 @@ object RankingTest extends Properties("Ranking Tests") {
     }
   }
 
+//  property("Highest Ranked Two pair wins ") = forAll(genTwoPair) { hand =>
+//    //    (hand match {
+//    //      case _: StraightFlush | _: Flush | _: Straight => false
+//    //      case _                                         => true
+//    //    }) ==> {
+//    hand match {
+//      case _: TwoPair => true
+//      case _          => false
+//    }
+//  }
+
 // This seems dumb now.  I need to generator groups of cards
   // not the hand???
   property("at least two cards of the same rank is a Pair") = forAll(genPair) { hand =>


### PR DESCRIPTION
Refactor from pairing with Keith!
- update scalafmt
- update sbt version
- clean up import statements
- use Cats Effect Random (instead of scala util Random)
- Street: Eliminate deal function to make implementation/state transition more precise. It is explicit that we can only move from one state to a specific state.  I believe previously it was implicit because of the pattern match.
- fix tests broken by change in Street API.